### PR TITLE
[Feat] 게시물 조회 뷰 통합 및 댓글 조회 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "router": "^1.3.8",
         "svgs": "^4.2.0",
         "vue": "^2.6.14",
+        "vue-cookies": "^1.8.3",
         "vue-infinite-loading": "^2.4.5",
         "vue-router": "^3.5.1",
         "vue-svg-loader": "^0.16.0",
@@ -17142,6 +17143,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/vue-cookies": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.8.3.tgz",
+      "integrity": "sha512-VBRsyRMVdahBgFfh389TMHPmDdr4URDJNMk4FKSCfuNITs7+jitBDhwyL4RJd3WUsfOYNNjPAkfbehyH9AFuoA=="
     },
     "node_modules/vue-eslint-parser": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "router": "^1.3.8",
     "svgs": "^4.2.0",
     "vue": "^2.6.14",
+    "vue-cookies": "^1.8.3",
     "vue-infinite-loading": "^2.4.5",
     "vue-router": "^3.5.1",
     "vue-svg-loader": "^0.16.0",

--- a/src/components/index/RightNavBar.vue
+++ b/src/components/index/RightNavBar.vue
@@ -1,6 +1,9 @@
 <template>
   <v-col cols="3">
-    <v-sheet rounded="lg" min-height="268" />
+    <v-sheet rounded="lg" min-height="268">
+      <v-container v-if="recruits">적절한 채용공고</v-container>
+      <v-container v-else>적절한 채용공고</v-container>
+    </v-sheet>
   </v-col>
 </template>
 
@@ -8,7 +11,7 @@
 export default {
   name: "right-nav-bar",
   data: () => ({
-    //
+    recruits: null,
   }),
 };
 </script>

--- a/src/components/reply/ReplyListModal.vue
+++ b/src/components/reply/ReplyListModal.vue
@@ -1,0 +1,39 @@
+<script>
+import ReplyComponent from "@/components/reply/component/ReplyComponent.vue";
+import ReplyInputComponent from "@/components/reply/component/ReplyInputComponent.vue";
+
+export default {
+  components: { ReplyInputComponent, ReplyComponent },
+  data: () => ({
+    replies: null,
+  }),
+  mounted() {
+    this.$axios
+      .get("/post/api/v1/posts/" + this.$route.params.postNo + "/replies", {
+        params: {
+          page: 0,
+          size: 5,
+        },
+        headers: {
+          accept: "application/json",
+          Authorization: "Bearer " + this.$cookies.get("access_token"),
+        },
+        withCredentials: true,
+      })
+      .then((response) => (this.replies = response.data));
+  },
+};
+</script>
+
+<template>
+  <v-responsive rounded="lg">
+    <v-flex>
+      <reply-component
+        v-for="reply in replies.content"
+        :key="reply.replyNo"
+        :reply="reply"
+      />
+    </v-flex>
+    <reply-input-component />
+  </v-responsive>
+</template>

--- a/src/components/reply/component/ReplyComponent.vue
+++ b/src/components/reply/component/ReplyComponent.vue
@@ -1,0 +1,32 @@
+<script>
+import ReplyWriterComponent from "@/components/reply/component/ReplyWriterComponent.vue";
+
+export default {
+  components: { ReplyWriterComponent },
+  props: {
+    reply: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+
+<template>
+  <v-list-item color="white" class="ma-1">
+    <reply-writer-component :writer="reply.writer" />
+    <v-list-item-content id="reply-write-info">
+      <v-list-item-title>
+        <p class="text-caption" v-if="reply.modifyAt !== null">
+          {{ reply.modifyAt }} (수정됨)
+        </p>
+        <p class="text-caption" v-else>
+          {{ reply.createAt }}
+        </p>
+      </v-list-item-title>
+      <v-list-item-content id="reply-content">
+        {{ reply.content }}
+      </v-list-item-content>
+    </v-list-item-content>
+  </v-list-item>
+</template>

--- a/src/components/reply/component/ReplyInputComponent.vue
+++ b/src/components/reply/component/ReplyInputComponent.vue
@@ -1,0 +1,26 @@
+<script>
+export default {
+  data: () => ({
+    rules: [
+      (value) => !!value || "입력 칸이 비어있어요.",
+      (value) => (value && value.length >= 2) || "길이가 너무 짧아요",
+    ],
+  }),
+  methods: {
+    submit() {
+      this.$v.$touch();
+    },
+  },
+};
+</script>
+
+<template>
+  <form>
+    <v-text-field
+      label="게시물에 댓글을 달아보세요"
+      :rules="rules"
+      hide-details="auto"
+    ></v-text-field>
+    <button type="submit" class="mr-4 v-btn--icon">submit</button>
+  </form>
+</template>

--- a/src/components/reply/component/ReplyWriterComponent.vue
+++ b/src/components/reply/component/ReplyWriterComponent.vue
@@ -1,0 +1,21 @@
+<script>
+export default {
+  props: {
+    writer: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+
+<template>
+  <v-list-item-avatar id="profile-thumbnail">
+    <v-img
+      v-if="writer.filePath"
+      :src="writer.filePath"
+      :alt="writer.username"
+    ></v-img>
+    <v-img v-else src="@/assets/user-no-image.png" alt="No Image"></v-img>
+  </v-list-item-avatar>
+</template>

--- a/src/pages/band/LeftBarBandList.vue
+++ b/src/pages/band/LeftBarBandList.vue
@@ -11,7 +11,13 @@ export default {
   methods: {
     fetchData() {
       this.$axios
-        .get("/user/api/v1/users/my-bands")
+        .get("/user/api/v1/users/my-bands", {
+          headers: {
+            Authorization: "Bearer " + this.$cookies.get("access_token"),
+            // FIXME 유저 식별 정보 넘어갈 수 있도록 수정
+            "X-TEMP-USER-NO": 117,
+          },
+        })
         .then((response) => {
           this.myBandList = response.data;
         })

--- a/src/pages/post/IntegrationPostView.vue
+++ b/src/pages/post/IntegrationPostView.vue
@@ -1,0 +1,115 @@
+<script>
+import { Viewer } from "@toast-ui/vue-editor";
+
+import "@toast-ui/editor/dist/toastui-editor-viewer.css";
+import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css";
+import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.js";
+import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js";
+
+import Prism from "prismjs";
+import "prismjs/themes/prism-solarizedlight.css";
+import PostBottomComponent from "@/pages/post/component/PostBottomComponent.vue";
+import PostHeaderComponent from "@/pages/post/component/PostHeaderComponent.vue";
+
+export default {
+  components: {
+    PostHeaderComponent,
+    PostBottomComponent,
+    Viewer,
+  },
+  data() {
+    return {
+      tuiOptions: {
+        plugins: [[codeSyntaxHighlight, { highlighter: Prism }]],
+      },
+      postData: null,
+      contentMore: false,
+      isReplyViewed: false,
+    };
+  },
+  created() {
+    this.fetchData();
+  },
+  methods: {
+    fetchData() {
+      this.$axios
+        .get("/post/api/v1/posts/" + this.$route.params.postNo, {
+          headers: {
+            Authorization: "Bearer " + this.$cookies.get("access_token"),
+          },
+        })
+        .then((response) => {
+          this.postData = response.data;
+          console.log(this.postData);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
+    },
+    toggleContentMore() {
+      this.contentMore = !this.contentMore;
+    },
+    getContentToShow() {
+      return this.contentMore
+        ? this.postData.post.content
+        : this.postData.post.content.substring(0, 300);
+    },
+  },
+  computed: {
+    shouldShowMoreLessButton() {
+      return this.postData && this.postData.post.content.length > 300;
+    },
+  },
+};
+</script>
+
+<template>
+  <v-sheet min-height="70vh" rounded="lg" class="main-body">
+    <v-responsive>
+      <post-header-component :post-data="postData" />
+      <br />
+      <v-divider></v-divider>
+      <div class="title">
+        <div v-if="postData.post.title !== null">
+          <p class="font-weight-bold text-center">
+            {{ postData.post.title }}
+          </p>
+        </div>
+        <Viewer
+          :options="tuiOptions"
+          :key="contentMore ? 'fullContent' : 'lessContent'"
+          :initialValue="getContentToShow()"
+        ></Viewer>
+        <div v-if="shouldShowMoreLessButton" class="text-right pr-3">
+          <v-btn icon plain retain-focus-on-click @click="toggleContentMore">
+            <span v-if="contentMore" class="text-caption">이전으로</span>
+            <span v-else class="text-caption">...더보기</span>
+            <v-icon>
+              {{ contentMore ? "mdi-chevron-up" : "mdi-chevron-down" }}
+            </v-icon>
+          </v-btn>
+        </div>
+      </div>
+      <v-carousel hide-delimiters height="auto" class="py-6">
+        <v-carousel-item
+          v-for="(item, index) in postData.post.file"
+          :key="index"
+        >
+          <v-img aspect-ratio="1.7" max-height="350" contain :src="item.path" />
+        </v-carousel-item>
+      </v-carousel>
+      <post-bottom-component />
+      <v-divider></v-divider>
+    </v-responsive>
+  </v-sheet>
+</template>
+
+<style scoped>
+.main-body {
+  padding-top: 1%;
+}
+
+.title {
+  padding: 2% 2%;
+}
+</style>

--- a/src/pages/post/component/PostBottomComponent.vue
+++ b/src/pages/post/component/PostBottomComponent.vue
@@ -1,0 +1,35 @@
+<script>
+import ReplyListModal from "@/components/reply/ReplyListModal.vue";
+
+export default {
+  components: { ReplyListModal },
+  data() {
+    return {
+      isReplyViewed: false,
+    };
+  },
+};
+</script>
+
+<template>
+  <v-bottom-navigation grow>
+    <v-btn>
+      <span>좋아요</span>
+      <v-icon>mdi-thumb-up-outline</v-icon>
+    </v-btn>
+    <v-btn>
+      <span>스크랩</span>
+      <v-icon>mdi-bookmark-outline</v-icon>
+    </v-btn>
+    <v-btn @click="isReplyViewed = true">
+      <span>댓글</span>
+      <v-icon>mdi-message-reply-text-outline</v-icon>
+    </v-btn>
+    <v-overlay v-if="isReplyViewed">
+      <v-layout>
+        <button @click="isReplyViewed = false">댓글창 닫기</button>
+      </v-layout>
+      <reply-list-modal />
+    </v-overlay>
+  </v-bottom-navigation>
+</template>

--- a/src/pages/post/component/PostHeaderComponent.vue
+++ b/src/pages/post/component/PostHeaderComponent.vue
@@ -1,0 +1,57 @@
+<script>
+import PostThreeDotMenuComponent from "@/pages/post/component/PostThreeDotMenuComponent.vue";
+
+export default {
+  components: {
+    PostThreeDotMenuComponent,
+  },
+  props: {
+    postData: {
+      type: Object,
+      required: true,
+    },
+  },
+};
+</script>
+
+<template>
+  <v-row class="d-flex flex-row writer">
+    <v-col cols="2">
+      <v-avatar size="55">
+        <v-img
+          :src="postData.writer.filePath"
+          :alt="postData.writer.username"
+          v-if="postData.writer.filePath"
+        ></v-img>
+        <v-img v-else src="@/assets/user-no-image.png" alt="No Image" />
+      </v-avatar>
+    </v-col>
+    <v-col class="flex-grow-1 align-self-start writer-name">
+      <h5>
+        {{ postData.writer.username }}
+      </h5>
+      <p class="text-caption" v-if="postData.post.modifyAt !== null">
+        {{ postData.post.modifyAt }} (수정됨)
+      </p>
+      <p class="text-caption" v-else>
+        {{ postData.post.createAt }}
+      </p>
+    </v-col>
+    <post-three-dot-menu-component />
+  </v-row>
+</template>
+
+<style scoped>
+.writer {
+  padding: 2% 4% 0 4%;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+}
+
+.writer-name {
+  white-space: nowrap;
+  padding-left: 2%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/pages/post/component/PostThreeDotMenuComponent.vue
+++ b/src/pages/post/component/PostThreeDotMenuComponent.vue
@@ -1,0 +1,38 @@
+<script>
+export default {
+  methods: {
+    copyLink() {
+      console.log("copy link");
+    },
+    alertReport() {
+      console.log("신고");
+    },
+  },
+};
+</script>
+
+<template>
+  <v-menu offset-y rounded left transition="slide-y-transition">
+    <template v-slot:activator="{ on }">
+      <v-btn icon v-on="on">
+        <v-icon>mdi-dots-horizontal</v-icon>
+      </v-btn>
+    </template>
+    <v-list>
+      <v-list dense rounded>
+        <v-list-item @click="copyLink">
+          <v-list-item-icon>
+            <v-icon>mdi-clippy</v-icon>
+          </v-list-item-icon>
+          <v-list-item-title>링크 복사</v-list-item-title>
+        </v-list-item>
+        <v-list-item @click="alertReport">
+          <v-list-item-icon>
+            <v-icon>mdi-alert-box-outline</v-icon>
+          </v-list-item-icon>
+          <v-list-item-title>신고</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-list>
+  </v-menu>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,8 +23,11 @@ import UserRegisterMainView from "@/pages/user/register/UserRegisterMainView.vue
 import LoginView from "@/pages/user/login/LoginView.vue";
 import PostMainView from "@/pages/post/PostMainView.vue";
 import SinglePost from "@/pages/post/SinglePost.vue";
+import IntegrationPostView from "@/pages/post/IntegrationPostView.vue";
+import VueCookies from "vue-cookies";
 
 Vue.use(VueRouter);
+Vue.use(VueCookies);
 
 const routes = [
   {
@@ -70,6 +73,19 @@ const routes = [
           {
             path: ":postNo",
             component: SinglePost,
+          },
+        ],
+      },
+      {
+        path: "/articles/integration",
+        component: PostMainView,
+        meta: {
+          title: "Aling - Integration Post",
+        },
+        children: [
+          {
+            path: ":postNo",
+            component: IntegrationPostView,
           },
         ],
       },


### PR DESCRIPTION
- 일반 게시물과 그룹 게시물 조회 Vue 통합하였습니다.
- 댓글 조회 추가하였습니다.

기존에 일반 게시물과 그룹 게시물 조회 url 이 분리되어있던 것을 모두 "/articles/integration/{postNo}" 로 가능하게 변경하였습니다. 
댓글 조회가 적용되어있으나 페이지네이션이 미적용되어있습니다. 
현재 배경이 반투명하게 되어있는데 작성 기능을 포함하여 완료 후 스타일 수정하여 가독성 개선하겠습니다.

<img width="440" alt="스크린샷 2024-03-06 오전 9 51 29" src="https://github.com/nhnacademy-ta-Aling/aling-front/assets/67360314/ceeb07e3-dba3-4a6c-95a0-e503f4f408d9">

